### PR TITLE
docs: add Swagger API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Sistema de votação seguro com verificação facial usando AWS Rekognition.
 ### Upload
 - `GET /api/v1/upload/presigned-url` - URL para upload de imagem
 
+## 📘 Documentação da API
+
+A documentação completa dos endpoints está disponível via **Swagger UI** após iniciar a aplicação:
+
+```
+http://localhost:8080/swagger-ui.html
+```
+
 ## 🔧 Desenvolvimento
 
 ### Pré-requisitos

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- OpenAPI/Swagger -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/rekognizevote/application/command/RegisterUserCommand.java
+++ b/src/main/java/com/rekognizevote/application/command/RegisterUserCommand.java
@@ -1,18 +1,23 @@
 package com.rekognizevote.application.command;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Request body for user registration")
 public record RegisterUserCommand(
+    @Schema(description = "User name", example = "Alice Doe")
     @NotBlank(message = "Name is required")
     @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
     String name,
-    
+
+    @Schema(description = "Email address", example = "alice@example.com")
     @NotBlank(message = "Email is required")
     @Email(message = "Invalid email format")
     String email,
-    
+
+    @Schema(description = "Password", example = "strongPass123")
     @NotBlank(message = "Password is required")
     @Size(min = 8, message = "Password must be at least 8 characters")
     String password

--- a/src/main/java/com/rekognizevote/infrastructure/config/OpenApiConfig.java
+++ b/src/main/java/com/rekognizevote/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.rekognizevote.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI apiInfo() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("RekognizeVote API")
+                .description("Secure voting API with facial recognition")
+                .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/rekognizevote/infrastructure/web/dto/AuthResponse.java
+++ b/src/main/java/com/rekognizevote/infrastructure/web/dto/AuthResponse.java
@@ -1,7 +1,13 @@
 package com.rekognizevote.infrastructure.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Authentication tokens and user info")
 public record AuthResponse(
+    @Schema(description = "JWT access token")
     String accessToken,
+    @Schema(description = "JWT refresh token")
     String refreshToken,
+    @Schema(description = "Registered user data")
     UserResponse user
 ) {}

--- a/src/main/java/com/rekognizevote/infrastructure/web/dto/UserResponse.java
+++ b/src/main/java/com/rekognizevote/infrastructure/web/dto/UserResponse.java
@@ -1,13 +1,19 @@
 package com.rekognizevote.infrastructure.web.dto;
 
 import com.rekognizevote.domain.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "User information")
 public record UserResponse(
+    @Schema(description = "User identifier", example = "42f41e48-9836-4aa4-8bf9-daf9b0fa8229")
     String id,
+    @Schema(description = "User name", example = "Alice Doe")
     String name,
+    @Schema(description = "Email address", example = "alice@example.com")
     String email,
+    @Schema(description = "Creation timestamp", example = "2024-05-13T13:51:08.123Z")
     Instant createdAt
 ) {
     public static UserResponse from(User user) {


### PR DESCRIPTION
## Summary
- add Springdoc OpenAPI dependency and configuration
- annotate auth registration endpoint and DTOs with Swagger metadata
- expose Swagger UI link in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a8a86ccb083318556181ce3cf01ff